### PR TITLE
Remove ugly yellow background from autofills

### DIFF
--- a/app/authui/styles.css
+++ b/app/authui/styles.css
@@ -115,3 +115,10 @@ body {
     top: 12px;
     padding: 10px;
 }
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover, 
+input:-webkit-autofill:focus, 
+input:-webkit-autofill:active{
+    -webkit-box-shadow: 0 0 0 30px white inset !important;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Introduced new styling for autofilled input elements by applying a white inset shadow during hover, focus, and active states to enhance the overall user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->